### PR TITLE
Move config folder to .config/aidea

### DIFF
--- a/aidea/tools.py
+++ b/aidea/tools.py
@@ -28,7 +28,7 @@ from requests_toolbelt import MultipartEncoder
 
 WEBSITE_URL = 'https://aidea-web.tw'
 API_SERVER_BASE_URL = f'{WEBSITE_URL}/api/v1'
-CONFIG_FOLDER = '.aidea'
+CONFIG_FOLDER = '.config/aidea'
 CONFIG_FILENAME = 'config.txt'
 
 


### PR DESCRIPTION
Consider moving .aidea folder to .config/aidea to keep $HOME clean and to abide by XDG Base Directory Specifications (https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).